### PR TITLE
Change link order

### DIFF
--- a/ports/v8/V8Config-static.cmake
+++ b/ports/v8/V8Config-static.cmake
@@ -1,13 +1,13 @@
 include(CMakeFindDependencyMacro)
-find_dependency(ICU REQUIRED COMPONENTS uc dt in)
+find_dependency(ICU REQUIRED COMPONENTS in uc dt)
 find_dependency(ZLIB REQUIRED)
 if(UNIX)
   find_package(unofficial-glib CONFIG REQUIRED)
   set(V8_IMPORTED_LINK_INTERFACE_LIBRARIES
-    "unofficial::glib::gmodule;unofficial::glib::gobject;unofficial::glib::gthread;ZLIB::ZLIB;ICU::uc;ICU::dt;ICU::in")
+    "ICU::in;ICU::uc;ICU::dt;unofficial::glib::gmodule;unofficial::glib::gobject;unofficial::glib::gthread;ZLIB::ZLIB")
 elseif(WIN32)
   set(V8_IMPORTED_LINK_INTERFACE_LIBRARIES
-    "Winmm;DbgHelp;ZLIB::ZLIB;ICU::uc;ICU::dt;ICU::in")
+    "Winmm;DbgHelp;ZLIB::ZLIB;ICU::in;ICU::uc;ICU::dt")
 endif()
 
 get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)


### PR DESCRIPTION
On Linux, the link order is important. Putting ICU first and in the order in, uc, dt works. Though not strictly necessary, for symmetry's sake I have changed the order on Windows, too.